### PR TITLE
Update promxy to v0.0.62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated promxy to v0.0.62
+
 ## [0.0.6] - 2020-10-08
 
 ### Added

--- a/helm/promxy-app/values.yaml
+++ b/helm/promxy-app/values.yaml
@@ -16,7 +16,7 @@ project:
 promxy:
   image:
     name: "giantswarm/promxy"
-    tag: "v0.0.60"
+    tag: "v0.0.62"
   port: 8082
 
   mountPath: /etc/promxy


### PR DESCRIPTION
@JosephSalisbury we can now define timeouts https://github.com/jacksontj/promxy/pull/359 using both timeout and ignore_error so we can use this for the global promxy instead of a handcrafted version