### PR TITLE
Fix `lint-chart` make target

### DIFF
--- a/Makefile.defs.mk
+++ b/Makefile.defs.mk
@@ -1,0 +1,1 @@
+APPLICATION := promxy-app


### PR DESCRIPTION
It requires variable `APPLICATION` to be set but the Makefiles
generated by `devctl` don't set it for `app` type.