### PR TITLE
Add team annotation to Chart.yaml for routing alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `application.giantswarm.io/team` annotation to Chart.yaml for routing
+alerts.
+
 ## [0.8.0] - 2021-02-08
 
 ### Changed

--- a/helm/promxy-app/Chart.yaml
+++ b/helm/promxy-app/Chart.yaml
@@ -4,3 +4,5 @@ description: Promxy is a prometheus proxy that makes many shards of prometheus a
 home: https://github.com/giantswarm/promxy
 version: [[ .Version ]]
 appVersion: v0.0.60
+annotations:
+  application.giantswarm.io/team: "atlas"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14846

Adding the new annotations here and in VPA to test them out.

```sh
kg port-forward app-exporter-unique-6b4bf4b6b9-9ccnd 8000:8000
curl -s http://localhost:8000/metrics | grep promxy-app

app_operator_app_info{app="promxy-app",catalog="control-plane-test-catalog",name="promxy-app-unique",namespace="giantswarm",status="deployed",team="atlas",version="0.8.0-0809b1cc325b6a6a7a6caea404a7527889c178c8"} 1
```