### PR TITLE
Revert "Add `Ingress` resource for root of the prometheus domain (#21)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reverted changes from 0.11.0 as they just moved Promxy to `/` with basic-auth
+
 ## [0.11.0] - 2021-04-20
 
 ### Added

--- a/helm/promxy-app/templates/deployment.yaml
+++ b/helm/promxy-app/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         - "--config={{ .Values.promxy.mountPath }}/config.yaml"
         - "--log-level=debug"
         - "--web.enable-lifecycle"
+        - "--web.external-url=/promxy"
         command:
         - "/bin/promxy"
         ports:
@@ -41,7 +42,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /promxy/-/healthy
             port: web
             scheme: HTTP
           periodSeconds: 5
@@ -50,7 +51,7 @@ spec:
         readinessProbe:
           failureThreshold: 120
           httpGet:
-            path: /-/ready
+            path: /promxy/-/ready
             port: web
             scheme: HTTP
           periodSeconds: 5
@@ -71,7 +72,7 @@ spec:
       - name: promxy-server-configmap-reload
         args:
         - "--volume-dir={{ .Values.promxy.mountPath }}"
-        - "--webhook-url=http://localhost:{{ .Values.promxy.port }}/-/reload"
+        - "--webhook-url=http://localhost:{{ .Values.promxy.port }}/promxy/-/reload"
         image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.promxy.configmapReloadImage.name }}:{{ .Values.promxy.configmapReloadImage.tag }}"
         resources:
           requests:

--- a/helm/promxy-app/templates/ingress.yaml
+++ b/helm/promxy-app/templates/ingress.yaml
@@ -1,19 +1,13 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "resource.default.name" . }}
   namespace: {{ include "resource.default.namespace" . }}
   annotations:
     kubernetes.io/ingress.class: nginx
-    {{- if .Values.Installation.V1.Monitoring.Prometheus.Letsencrypt }}
-    kubernetes.io/tls-acme: "true"
-    {{- end }}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: {{ include "resource.default.name" . }}
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
-    {{- if .Values.Installation.V1.Security.RestrictAccess.Enabled }}
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.Installation.V1.Security.Subnet.VPN }}"
-    {{- end }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
@@ -24,7 +18,7 @@ spec:
       - backend:
           serviceName: {{ include "resource.default.name" . }}
           servicePort: {{ .Values.promxy.port }}
-        path: /
+        path: /promxy
   tls:
   - hosts:
     - {{ .Values.Installation.V1.Monitoring.Prometheus.Host }}


### PR DESCRIPTION
This reverts commit 684ffc8eb514ef305781504fb2a5ef3252bd195d.

Towards: https://github.com/giantswarm/giantswarm/issues/12864