### PR TITLE
Fix managed-by selector

### DIFF
--- a/config/promxy.yaml
+++ b/config/promxy.yaml
@@ -16,7 +16,7 @@ data:
         - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_managed_by, __meta_kubernetes_pod_label_app_kubernetes_io_name,
             __meta_kubernetes_pod_label_app_kubernetes_io_instance]
           separator: ;
-          regex: prometheus-meta-operator;prometheus;.+
+          regex: prometheus-operator;prometheus;.+
           action: keep
         - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
           target_label: cluster_id


### PR DESCRIPTION
The managed-by label is now overriden by prometheus-operator since 0.47.0
https://github.com/prometheus-operator/prometheus-operator/commit/6dd48d4f668c391ff30d7892fcfd1b6494b83291#diff-930519027f29e25f016e4d8134774e70edcc0c7ab725c5a664dd66da55d07392