### PR TITLE
Run as non root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix
+
+- Run promxy as a non root user.
+
 ## [1.14.0] - 2022-02-16
 
 ### Changed

--- a/helm/promxy-app/templates/deployment.yaml
+++ b/helm/promxy-app/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
+        runAsNonRoot: true
       containers:
       - name: {{ include "name" . }}
         image: "{{ .Values.registry.domain }}/{{ .Values.promxy.image.name }}:{{ .Values.promxy.image.tag }}"

--- a/helm/promxy-app/values.yaml
+++ b/helm/promxy-app/values.yaml
@@ -7,7 +7,7 @@ monitoring:
 
 pod:
   user:
-    id: 0
+    id: 1000
   group:
     id: 1000
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22291. This PR fixes a security issue to ensure promxy is not running as root

Tested on Gauss

```sh
k get pods -n monitoring | grep promxy
promxy-app-69bfd75588-66xrv                          2/2     Running     0          4m29s
promxy-app-69bfd75588-pc854                          2/2     Running     0          4m29s
```
