### PR TITLE
resources limits and requests moved to values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- resources limits and request can now be defined in values
+
 ## [1.16.1] - 2022-11-08
 
 ### Changed

--- a/helm/promxy-app/templates/deployment.yaml
+++ b/helm/promxy-app/templates/deployment.yaml
@@ -57,13 +57,10 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 3
+        {{- with .Values.promxy.resources }}
         resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
-          limits:
-            cpu: 500m
-            memory: 500Mi
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: "{{ .Values.promxy.mountPath }}"
           name: promxy-config
@@ -74,13 +71,10 @@ spec:
         - "--volume-dir={{ .Values.promxy.mountPath }}"
         - "--webhook-url=http://localhost:{{ .Values.promxy.port }}/-/reload"
         image: "{{ .Values.registry.domain }}/{{ .Values.promxy.configmapReloadImage.name }}:{{ .Values.promxy.configmapReloadImage.tag }}"
+        {{- with .Values.promxy.configmapReloadResources }}
         resources:
-          requests:
-            cpu: 25m
-            memory: 25Mi
-          limits:
-            cpu: 25m
-            memory: 25Mi
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: "{{ .Values.promxy.mountPath }}"
           name: promxy-config

--- a/helm/promxy-app/values.yaml
+++ b/helm/promxy-app/values.yaml
@@ -21,6 +21,14 @@ promxy:
     tag: "v0.0.75"
   port: 8082
 
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 500m
+      memory: 500Mi
+
   mountPath: /etc/promxy
 
   service:
@@ -29,6 +37,14 @@ promxy:
   configmapReloadImage:
     name: giantswarm/configmap-reload
     tag: v0.3.0
+
+  configmapReloadResources:
+    requests:
+      cpu: 25m
+      memory: 25Mi
+    limits:
+      cpu: 25m
+      memory: 25Mi
 
   serverGroups: []
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24777

Move resource limits and requests to values, so it's user-tunable.


## Tests with a local render with local values:
Renders generated with:
```
helm template promxy helm/promxy-app > render-xxx.yaml
```

Results:
```
$ diff render-origin.yaml render-next.yaml 
325,327d324
<           requests:
<             cpu: 100m
<             memory: 100Mi
330a328,330
>           requests:
>             cpu: 100m
>             memory: 100Mi
342c342
<           requests:
---
>           limits:
345c345
<           limits:
---
>           requests:
```
`limits` and `requests` are not in the same order in the `next` render, but apart from that all is the same. :+1: 