### PR TITLE
enable external-dns support on ingress objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add additional annotations on all `ingress` objects to support DNS record creation via `external-dns`.
 - Added the use of the runtime/default seccomp profile.
 
 ## [1.17.1] - 2023-01-10

--- a/helm/promxy-app/templates/ingress-basic-auth.yaml
+++ b/helm/promxy-app/templates/ingress-basic-auth.yaml
@@ -20,6 +20,10 @@ metadata:
     {{- if .Values.security.restrictAccess.enabled }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.security.subnet.vpn }}"
     {{- end }}
+    {{- if .Values.ingress.externalDNS }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.monitoring.prometheus.host }}
+    giantswarm.io/external-dns: managed
+    {{- end }}    
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/promxy-app/templates/ingress-oauth.yaml
+++ b/helm/promxy-app/templates/ingress-oauth.yaml
@@ -17,6 +17,10 @@ metadata:
     {{- if .Values.security.restrictAccess.enabled }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.security.subnet.vpn }}"
     {{- end }}
+    {{- if .Values.ingress.externalDNS }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.monitoring.prometheus.host }}
+    giantswarm.io/external-dns: managed
+    {{- end }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/promxy-app/values.schema.json
+++ b/helm/promxy-app/values.schema.json
@@ -169,6 +169,14 @@
                 }
             }
         },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "externalDNS": {
+                    "type": "boolean"
+                }
+            }
+        },
         "registry": {
             "type": "object",
             "properties": {

--- a/helm/promxy-app/values.yaml
+++ b/helm/promxy-app/values.yaml
@@ -54,6 +54,9 @@ security:
   subnet:
     vpn: ""
 
+ingress:
+  externalDNS: false
+
 registry:
   domain: quay.io
   pullSecret:


### PR DESCRIPTION
to support dns-record creation via external-dns, two additional annotations are needed to make external-dns work on promxy created ingress objects.

towards: https://github.com/giantswarm/roadmap/issues/1037
related config repo change: https://github.com/giantswarm/config/pull/1604