### PR TITLE
Add ClusterIssuerName configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Possibility to configure used ClusterIssuer name for Ingresses.
+
 ## [1.20.0] - 2023-07-04
 
 ### Changed

--- a/helm/promxy-app/templates/ingress-basic-auth.yaml
+++ b/helm/promxy-app/templates/ingress-basic-auth.yaml
@@ -10,6 +10,9 @@ metadata:
   annotations:
     {{- if .Values.monitoring.prometheus.letsencrypt }}
     kubernetes.io/tls-acme: "true"
+    {{- with .Values.monitoring.prometheus.clusterIssuerName }}
+    cert-manager.io/cluster-issuer: "{{ . }}"
+    {{- end }}
     {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     # basic-auth for global Promxy to be able to access all installation-level

--- a/helm/promxy-app/templates/ingress-oauth.yaml
+++ b/helm/promxy-app/templates/ingress-oauth.yaml
@@ -10,6 +10,9 @@ metadata:
   annotations:
     {{- if .Values.monitoring.prometheus.letsencrypt }}
     kubernetes.io/tls-acme: "true"
+    {{- with .Values.monitoring.prometheus.clusterIssuerName }}
+    cert-manager.io/cluster-issuer: "{{ . }}"
+    {{- end }}
     {{- end }}
     # OAuth2 SSO access for humans
     nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$escaped_request_uri

--- a/helm/promxy-app/values.schema.json
+++ b/helm/promxy-app/values.schema.json
@@ -27,6 +27,9 @@
                 "prometheus": {
                     "type": "object",
                     "properties": {
+                        "clusterIssuerName": {
+                            "type": "string"
+                        },
                         "host": {
                             "type": "string"
                         },

--- a/helm/promxy-app/values.yaml
+++ b/helm/promxy-app/values.yaml
@@ -7,6 +7,7 @@ monitoring:
   prometheus:
     host: ""
     letsencrypt: true
+    clusterIssuerName: ""
   promxy:
     htpasswd: ""
 


### PR DESCRIPTION
This PR introduces a new configuration option to specify the name of the cert-manager ClusterIssuer to be used on Ingress resources installed by the chart in this repository.

Towards https://github.com/giantswarm/roadmap/issues/2844