### PR TITLE
Ingress: Use `ImplementationSpecific`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ingress: Use `ImplementationSpecific`. ([#161](https://github.com/giantswarm/promxy-app/pull/161))
+
 ## [1.22.0] - 2023-10-03
 
 ### Changed

--- a/helm/promxy-app/templates/ingress-basic-auth.yaml
+++ b/helm/promxy-app/templates/ingress-basic-auth.yaml
@@ -36,7 +36,7 @@ spec:
     http:
       paths:
       - path: /promxy(/|$)(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           service:


### PR DESCRIPTION
Current version of `ingress-nginx` has [`strict-validate-path-type`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#strict-validate-path-type) enabled by default. To conform to this, the `pathType` of this `Ingress` resource must be `ImplementationSpecific` as it's using regular expressions.

This is preventing us from upgrade Ingress NGINX Controller on management clusters.

Towards https://github.com/giantswarm/giantswarm/issues/28509.