### PR TITLE
Remove promxy from CAPA and CAPZ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,17 +57,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
-          name: capz-app-collection
-          app_name: "promxy-app"
-          app_namespace: "monitoring"
-          app_collection_repo: "capz-app-collection"
-          requires:
-            - app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,21 +32,6 @@ workflows:
 
       - architect/push-to-app-collection:
           context: architect
-          name: azure-app-collection
-          app_name: "promxy-app"
-          app_namespace: "monitoring"
-          app_collection_repo: "azure-app-collection"
-          requires:
-            - app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-
-      - architect/push-to-app-collection:
-          context: architect
           name: vsphere-app-collection
           app_name: "promxy-app"
           app_namespace: "monitoring"
@@ -75,38 +60,10 @@ workflows:
 
       - architect/push-to-app-collection:
           context: architect
-          name: capa-app-collection
-          app_name: "promxy-app"
-          app_namespace: "monitoring"
-          app_collection_repo: "capa-app-collection"
-          requires:
-            - app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
           name: capz-app-collection
           app_name: "promxy-app"
           app_namespace: "monitoring"
           app_collection_repo: "capz-app-collection"
-          requires:
-            - app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
-          name: gcp-app-collection
-          app_name: "promxy-app"
-          app_namespace: "monitoring"
-          app_collection_repo: "gcp-app-collection"
           requires:
             - app-catalog
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,31 +29,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
-          name: vsphere-app-collection
-          app_name: "promxy-app"
-          app_namespace: "monitoring"
-          app_collection_repo: "vsphere-app-collection"
-          requires:
-            - app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
-          name: cloud-director-app-collection
-          app_name: "promxy-app"
-          app_namespace: "monitoring"
-          app_collection_repo: "cloud-director-app-collection"
-          requires:
-            - app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/


### PR DESCRIPTION
Towards giantswarm/roadmap#3218 this PR removes Promxy from CAPA.